### PR TITLE
Build docker images with api dependency fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,11 @@ FROM node:18-alpine as backend
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies and create non-root user
-RUN apk add --no-cache postgresql-client dumb-init && \
+# Update package index and install system dependencies
+RUN apk update && \
+    apk add --no-cache postgresql-client dumb-init || \
+    (echo "Primary repo failed, trying community repo..." && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.18/community postgresql-client dumb-init) && \
     addgroup -g 1001 -S nodejs && \
     adduser -S appuser -u 1001 -G nodejs
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,8 +4,11 @@ FROM node:18-alpine
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies and create non-root user
-RUN apk add --no-cache postgresql-client dumb-init && \
+# Update package index and install system dependencies
+RUN apk update && \
+    apk add --no-cache postgresql-client dumb-init || \
+    (echo "Primary repo failed, trying community repo..." && \
+     apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.18/community postgresql-client dumb-init) && \
     addgroup -g 1001 -S nodejs && \
     adduser -S appuser -u 1001 -G nodejs
 


### PR DESCRIPTION
Add a fallback mechanism for `apk add` commands in Dockerfiles to improve build resilience against Alpine repository issues.

The previous `apk add postgresql-client` command was failing due to temporary network issues or the package being unavailable in the default Alpine repositories. This change introduces a fallback to a specific community repository mirror if the primary installation fails, ensuring the build can complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f2ca22a-458c-4bae-9bef-122e53c24cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f2ca22a-458c-4bae-9bef-122e53c24cd2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

